### PR TITLE
chore: make mock_dependencies() return correcly typed struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "injective-cosmwasm"
-version = "0.1.46"
+version = "0.1.47"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/atomic-order-example/src/tests.rs
+++ b/contracts/atomic-order-example/src/tests.rs
@@ -119,8 +119,13 @@ fn test_swap() {
         },
     };
 
-    if let InjectiveMsg::Deposit {sender,subaccount_id: _subaccount_id, amount: _amount } = &get_message_data(&res.messages, 0).msg_data {
-            assert_eq!(sender, contract_addr, "sender not correct")
+    if let InjectiveMsg::Deposit {
+        sender,
+        subaccount_id: _subaccount_id,
+        amount: _amount,
+    } = &get_message_data(&res.messages, 0).msg_data
+    {
+        assert_eq!(sender, contract_addr, "sender not correct")
     }
     let order_message = get_message_data(&res.messages, 1);
     assert_eq!(
@@ -146,17 +151,27 @@ fn test_swap() {
     let messages = transfers_response.unwrap().messages;
     assert_eq!(messages.len(), 3);
 
-    if let InjectiveMsg::Withdraw {sender, subaccount_id: _subaccount_id, amount} = &get_message_data(&messages, 0).msg_data {
+    if let InjectiveMsg::Withdraw {
+        sender,
+        subaccount_id: _subaccount_id,
+        amount,
+    } = &get_message_data(&messages, 0).msg_data
+    {
         assert_eq!(sender, contract_addr, "sender not correct");
         assert_eq!(amount.amount, Uint128::from(8u128));
     } else {
         panic!("Wrong message type!");
     }
 
-    if let  InjectiveMsg::Withdraw {sender, subaccount_id: _subaccount_id, amount, } = &get_message_data(&messages, 1).msg_data {
-            assert_eq!(sender, contract_addr, "sender not correct");
-            assert_eq!(amount.amount, Uint128::from(9000u128 - 8036u128));
-        } else {
+    if let InjectiveMsg::Withdraw {
+        sender,
+        subaccount_id: _subaccount_id,
+        amount,
+    } = &get_message_data(&messages, 1).msg_data
+    {
+        assert_eq!(sender, contract_addr, "sender not correct");
+        assert_eq!(amount.amount, Uint128::from(9000u128 - 8036u128));
+    } else {
         panic!("Wrong message type!");
     }
 

--- a/contracts/atomic-order-example/src/tests.rs
+++ b/contracts/atomic-order-example/src/tests.rs
@@ -119,15 +119,8 @@ fn test_swap() {
         },
     };
 
-    match &get_message_data(&res.messages, 0).msg_data {
-        InjectiveMsg::Deposit {
-            sender,
-            subaccount_id: _subaccount_id,
-            amount: _amount,
-        } => {
+    if let InjectiveMsg::Deposit {sender,subaccount_id: _subaccount_id, amount: _amount } = &get_message_data(&res.messages, 0).msg_data {
             assert_eq!(sender, contract_addr, "sender not correct")
-        }
-        _ => {}
     }
     let order_message = get_message_data(&res.messages, 1);
     assert_eq!(
@@ -152,43 +145,30 @@ fn test_swap() {
     let transfers_response = reply(deps.as_mut_deps(), inj_mock_env(), reply_msg);
     let messages = transfers_response.unwrap().messages;
     assert_eq!(messages.len(), 3);
-    match &get_message_data(&messages, 0).msg_data {
-        // base
-        InjectiveMsg::Withdraw {
-            sender,
-            subaccount_id: _subaccount_id,
-            amount,
-        } => {
-            assert_eq!(sender, contract_addr, "sender not correct");
-            assert_eq!(amount.amount, Uint128::from(8u128));
-        }
-        _ => panic!("Wrong message type!"),
+
+    if let InjectiveMsg::Withdraw {sender, subaccount_id: _subaccount_id, amount} = &get_message_data(&messages, 0).msg_data {
+        assert_eq!(sender, contract_addr, "sender not correct");
+        assert_eq!(amount.amount, Uint128::from(8u128));
+    } else {
+        panic!("Wrong message type!");
     }
-    match &get_message_data(&messages, 1).msg_data {
-        // leftover quote
-        InjectiveMsg::Withdraw {
-            sender,
-            subaccount_id: _subaccount_id,
-            amount,
-        } => {
+
+    if let  InjectiveMsg::Withdraw {sender, subaccount_id: _subaccount_id, amount, } = &get_message_data(&messages, 1).msg_data {
             assert_eq!(sender, contract_addr, "sender not correct");
             assert_eq!(amount.amount, Uint128::from(9000u128 - 8036u128));
-        }
-        _ => panic!("Wrong message type!"),
+        } else {
+        panic!("Wrong message type!");
     }
-    match &messages[2].msg {
-        CosmosMsg::Bank(bank_msg) => match bank_msg {
-            BankMsg::Send { to_address, amount } => {
-                assert_eq!(to_address, sender_addr);
-                assert_eq!(2, amount.len());
-                assert_eq!(amount[0].denom, "INJ");
-                assert_eq!(amount[0].amount, Uint128::from(8u128));
-                assert_eq!(amount[1].denom, "USDT");
-                assert_eq!(amount[1].amount, Uint128::from(9000u128 - 8036u128));
-            }
-            _ => panic!("Wrong message type!"),
-        },
-        _ => panic!("Wrong message type!"),
+
+    if let CosmosMsg::Bank(BankMsg::Send { to_address, amount }) = &messages[2].msg {
+        assert_eq!(to_address, sender_addr);
+        assert_eq!(2, amount.len());
+        assert_eq!(amount[0].denom, "INJ");
+        assert_eq!(amount[0].amount, Uint128::from(8u128));
+        assert_eq!(amount[1].denom, "USDT");
+        assert_eq!(amount[1].amount, Uint128::from(9000u128 - 8036u128));
+    } else {
+        panic!("Wrong message type!");
     }
 }
 

--- a/contracts/registry/src/contract.rs
+++ b/contracts/registry/src/contract.rs
@@ -106,10 +106,7 @@ pub fn try_register(
     is_executable: bool,
 ) -> Result<Response, ContractError> {
     // Validate Authorization
-    let res = only_registry(env, info);
-    if let Err(error) = res {
-        return Err(error);
-    }
+    only_registry(env, info)?;
 
     let contract = CONTRACT {
         gas_limit,
@@ -142,10 +139,7 @@ pub fn try_update(
     let mut contract = CONTRACTS.load(deps.storage, &contract_addr)?;
 
     // Validate Authorization
-    let res = only_owner_or_registry(&contract_addr, &deps, env, info);
-    if let Err(error) = res {
-        return Err(error);
-    }
+    only_owner_or_registry(&contract_addr, &deps, env, info)?;
 
     // update the contract
     if gas_limit != 0 {
@@ -173,10 +167,7 @@ pub fn try_activate(
     let mut contract = CONTRACTS.load(deps.storage, &contract_addr)?;
 
     // Validate Authorization
-    let res = only_owner_or_registry(&contract_addr, &deps, env, info);
-    if let Err(error) = res {
-        return Err(error);
-    }
+    only_owner_or_registry(&contract_addr, &deps, env, info)?;
 
     // update the contract to be executable
     contract.is_executable = true;
@@ -201,10 +192,7 @@ pub fn try_deactivate(
     let mut contract = CONTRACTS.load(deps.storage, &contract_addr)?;
 
     // Validate Authorization
-    let res = only_owner_or_registry(&contract_addr, &deps, env, info);
-    if let Err(error) = res {
-        return Err(error);
-    }
+    only_owner_or_registry(&contract_addr, &deps, env, info)?;
 
     contract.is_executable = false;
 

--- a/packages/injective-cosmwasm/Cargo.toml
+++ b/packages/injective-cosmwasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "injective-cosmwasm"
-version = "0.1.46"
+version = "0.1.47"
 authors = ["Albert Chon <albert@injectivelabs.org>"]
 edition = "2018"
 description = "Bindings for CosmWasm contracts to call into custom modules of Injective Core"

--- a/packages/injective-cosmwasm/src/exchange_mock_querier.rs
+++ b/packages/injective-cosmwasm/src/exchange_mock_querier.rs
@@ -16,7 +16,7 @@ use crate::{
     SubaccountEffectivePositionInMarketResponse, SubaccountPositionInMarketResponse, TraderDerivativeOrdersResponse, TraderSpotOrdersResponse,
 };
 
-pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier> {
+pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier, InjectiveQueryWrapper> {
     let custom_querier: WasmMockQuerier = WasmMockQuerier::new();
 
     OwnedDeps {
@@ -216,7 +216,7 @@ impl Querier for WasmMockQuerier {
             Ok(v) => v,
             Err(e) => {
                 return SystemResult::Err(SystemError::InvalidRequest {
-                    error: format!("Parsing query request: {}", e),
+                    error: format!("Parsing query request: {:?}", e),
                     request: bin_request.into(),
                 })
             }


### PR DESCRIPTION
If we change the type of  `OwnedDeps` returned by `mock_dependencies` to `OwnedDeps<MockStorage, MockApi, WasmMockQuerier, InjectiveQueryWrapper>`, then we can simply call `to_mut()` on the varaible and pass it to functions that require `DepsMut<InjectiveQueryWrapper>`