### PR TITLE
Chore/borrow not move

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "injective-cosmwasm"
-version = "0.1.67"
+version = "0.1.69"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/atomic-order-example/src/contract.rs
+++ b/contracts/atomic-order-example/src/contract.rs
@@ -33,7 +33,7 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response<InjectiveMsgWrapper>, ContractError> {
     let querier = InjectiveQuerier::new(&deps.querier);
-    if let Some(market) = querier.query_spot_market(msg.market_id.clone())?.market {
+    if let Some(market) = querier.query_spot_market(&msg.market_id)?.market {
         let state = ContractConfigState {
             market_id: msg.market_id,
             base_denom: market.base_denom,

--- a/packages/injective-cosmwasm/Cargo.toml
+++ b/packages/injective-cosmwasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "injective-cosmwasm"
-version = "0.1.67"
+version = "0.1.69"
 authors = ["Albert Chon <albert@injectivelabs.org>"]
 edition = "2018"
 description = "Bindings for CosmWasm contracts to call into custom modules of Injective Core"

--- a/packages/injective-cosmwasm/src/querier.rs
+++ b/packages/injective-cosmwasm/src/querier.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use cosmwasm_std::{QuerierWrapper, StdResult};
 
 use injective_math::FPDecimal;

--- a/packages/injective-cosmwasm/src/querier.rs
+++ b/packages/injective-cosmwasm/src/querier.rs
@@ -23,16 +23,16 @@ impl<'a> InjectiveQuerier<'a> {
         InjectiveQuerier { querier }
     }
 
-    pub fn query_subaccount_deposit<T: Into<SubaccountId>, P: Into<String>>(
+    pub fn query_subaccount_deposit<T: Into<SubaccountId> + Clone, P: Into<String> + Clone>(
         &self,
-        subaccount_id: T,
-        denom: P,
+        subaccount_id: &'a T,
+        denom: &'a P,
     ) -> StdResult<SubaccountDepositResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::SubaccountDeposit {
-                subaccount_id: subaccount_id.into(),
-                denom: denom.into(),
+                subaccount_id: subaccount_id.clone().into(),
+                denom: denom.clone().into(),
             },
         };
 
@@ -52,26 +52,28 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_spot_market<T: Into<MarketId>>(&self, market_id: T) -> StdResult<SpotMarketResponse> {
+    pub fn query_spot_market<T: Into<MarketId> + Clone>(&self, market_id: &'a T) -> StdResult<SpotMarketResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
-            query_data: InjectiveQuery::SpotMarket { market_id: market_id.into() },
+            query_data: InjectiveQuery::SpotMarket {
+                market_id: market_id.clone().into(),
+            },
         };
 
         let res: SpotMarketResponse = self.querier.query(&request.into())?;
         Ok(res)
     }
 
-    pub fn query_effective_subaccount_position<T: Into<MarketId>, P: Into<SubaccountId>>(
+    pub fn query_effective_subaccount_position<T: Into<MarketId> + Clone, P: Into<SubaccountId> + Clone>(
         &self,
-        market_id: T,
-        subaccount_id: P,
+        market_id: &'a T,
+        subaccount_id: &'a P,
     ) -> StdResult<SubaccountEffectivePositionInMarketResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::SubaccountEffectivePositionInMarket {
-                market_id: market_id.into(),
-                subaccount_id: subaccount_id.into(),
+                market_id: market_id.clone().into(),
+                subaccount_id: subaccount_id.clone().into(),
             },
         };
 
@@ -79,16 +81,16 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_vanilla_subaccount_position<T: Into<MarketId>, P: Into<SubaccountId>>(
+    pub fn query_vanilla_subaccount_position<T: Into<MarketId> + Clone, P: Into<SubaccountId> + Clone>(
         &self,
-        market_id: T,
-        subaccount_id: P,
+        market_id: &'a T,
+        subaccount_id: &'a P,
     ) -> StdResult<SubaccountPositionInMarketResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::SubaccountPositionInMarket {
-                market_id: market_id.into(),
-                subaccount_id: subaccount_id.into(),
+                market_id: market_id.clone().into(),
+                subaccount_id: subaccount_id.clone().into(),
             },
         };
 
@@ -96,16 +98,16 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_trader_derivative_orders<T: Into<MarketId>, P: Into<SubaccountId>>(
+    pub fn query_trader_derivative_orders<T: Into<MarketId> + Clone, P: Into<SubaccountId> + Clone>(
         &self,
-        market_id: T,
-        subaccount_id: P,
+        market_id: &'a T,
+        subaccount_id: &'a P,
     ) -> StdResult<TraderDerivativeOrdersResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::TraderDerivativeOrders {
-                market_id: market_id.into(),
-                subaccount_id: subaccount_id.into(),
+                market_id: market_id.clone().into(),
+                subaccount_id: subaccount_id.clone().into(),
             },
         };
 
@@ -113,16 +115,16 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_trader_transient_spot_orders<T: Into<MarketId>, P: Into<SubaccountId>>(
+    pub fn query_trader_transient_spot_orders<T: Into<MarketId> + Clone, P: Into<SubaccountId> + Clone>(
         &self,
-        market_id: T,
-        subaccount_id: P,
+        market_id: &'a T,
+        subaccount_id: &'a P,
     ) -> StdResult<TraderSpotOrdersResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::TraderTransientSpotOrders {
-                market_id: market_id.into(),
-                subaccount_id: subaccount_id.into(),
+                market_id: market_id.clone().into(),
+                subaccount_id: subaccount_id.clone().into(),
             },
         };
 
@@ -130,16 +132,16 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_trader_transient_derivative_orders<T: Into<MarketId>, P: Into<SubaccountId>>(
+    pub fn query_trader_transient_derivative_orders<T: Into<MarketId> + Clone, P: Into<SubaccountId> + Clone>(
         &self,
-        market_id: T,
-        subaccount_id: P,
+        market_id: &'a T,
+        subaccount_id: &'a P,
     ) -> StdResult<TraderDerivativeOrdersResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::TraderTransientDerivativeOrders {
-                market_id: market_id.into(),
-                subaccount_id: subaccount_id.into(),
+                market_id: market_id.clone().into(),
+                subaccount_id: subaccount_id.clone().into(),
             },
         };
 
@@ -147,16 +149,16 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_trader_spot_orders<T: Into<MarketId>, P: Into<SubaccountId>>(
+    pub fn query_trader_spot_orders<T: Into<MarketId> + Clone, P: Into<SubaccountId> + Clone>(
         &self,
-        market_id: T,
-        subaccount_id: P,
+        market_id: &'a T,
+        subaccount_id: &'a P,
     ) -> StdResult<TraderSpotOrdersResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::TraderSpotOrders {
-                market_id: market_id.into(),
-                subaccount_id: subaccount_id.into(),
+                market_id: market_id.clone().into(),
+                subaccount_id: subaccount_id.clone().into(),
             },
         };
 
@@ -164,10 +166,10 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_spot_orders_to_cancel_up_to_amount<T: Into<MarketId>, P: Into<SubaccountId>>(
+    pub fn query_spot_orders_to_cancel_up_to_amount<T: Into<MarketId> + Clone, P: Into<SubaccountId> + Clone>(
         &self,
-        market_id: T,
-        subaccount_id: P,
+        market_id: &'a T,
+        subaccount_id: &'a P,
         base_amount: FPDecimal,
         quote_amount: FPDecimal,
         strategy: i32,
@@ -176,8 +178,8 @@ impl<'a> InjectiveQuerier<'a> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::TraderSpotOrdersToCancelUpToAmount {
-                market_id: market_id.into(),
-                subaccount_id: subaccount_id.into(),
+                market_id: market_id.clone().into(),
+                subaccount_id: subaccount_id.clone().into(),
                 base_amount,
                 quote_amount,
                 strategy,
@@ -189,10 +191,10 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_derivative_orders_to_cancel_up_to_amount<T: Into<MarketId>, P: Into<SubaccountId>>(
+    pub fn query_derivative_orders_to_cancel_up_to_amount<T: Into<MarketId> + Clone, P: Into<SubaccountId> + Clone>(
         &self,
-        market_id: T,
-        subaccount_id: P,
+        market_id: &'a T,
+        subaccount_id: &'a P,
         quote_amount: FPDecimal,
         strategy: i32,
         reference_price: Option<FPDecimal>,
@@ -200,8 +202,8 @@ impl<'a> InjectiveQuerier<'a> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::TraderDerivativeOrdersToCancelUpToAmount {
-                market_id: market_id.into(),
-                subaccount_id: subaccount_id.into(),
+                market_id: market_id.clone().into(),
+                subaccount_id: subaccount_id.clone().into(),
                 quote_amount,
                 strategy,
                 reference_price,
@@ -212,29 +214,33 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_perpetual_market_info<T: Into<MarketId>>(&self, market_id: T) -> StdResult<PerpetualMarketInfoResponse> {
+    pub fn query_perpetual_market_info<T: Into<MarketId> + Clone>(&self, market_id: &'a T) -> StdResult<PerpetualMarketInfoResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
-            query_data: InjectiveQuery::PerpetualMarketInfo { market_id: market_id.into() },
+            query_data: InjectiveQuery::PerpetualMarketInfo {
+                market_id: market_id.clone().into(),
+            },
         };
 
         let res: PerpetualMarketInfoResponse = self.querier.query(&request.into())?;
         Ok(res)
     }
 
-    pub fn query_perpetual_market_funding<T: Into<MarketId>>(&self, market_id: T) -> StdResult<PerpetualMarketFundingResponse> {
+    pub fn query_perpetual_market_funding<T: Into<MarketId> + Clone>(&self, market_id: &'a T) -> StdResult<PerpetualMarketFundingResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
-            query_data: InjectiveQuery::PerpetualMarketFunding { market_id: market_id.into() },
+            query_data: InjectiveQuery::PerpetualMarketFunding {
+                market_id: market_id.clone().into(),
+            },
         };
 
         let res: PerpetualMarketFundingResponse = self.querier.query(&request.into())?;
         Ok(res)
     }
 
-    pub fn query_market_volatility<T: Into<MarketId>>(
+    pub fn query_market_volatility<T: Into<MarketId> + Clone>(
         &self,
-        market_id: T,
+        market_id: &'a T,
         trade_grouping_sec: u64,
         max_age: u64,
         include_raw_history: bool,
@@ -243,7 +249,7 @@ impl<'a> InjectiveQuerier<'a> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::MarketVolatility {
-                market_id: market_id.into(),
+                market_id: market_id.clone().into(),
                 trade_history_options: TradeHistoryOptions {
                     trade_grouping_sec,
                     max_age,
@@ -257,20 +263,27 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_derivative_market_mid_price_and_tob<T: Into<MarketId>>(&self, market_id: T) -> StdResult<DerivativeMarketMidPriceAndTOBResponse> {
+    pub fn query_derivative_market_mid_price_and_tob<T: Into<MarketId> + Clone>(
+        &self,
+        market_id: &'a T,
+    ) -> StdResult<DerivativeMarketMidPriceAndTOBResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
-            query_data: InjectiveQuery::DerivativeMarketMidPriceAndTob { market_id: market_id.into() },
+            query_data: InjectiveQuery::DerivativeMarketMidPriceAndTob {
+                market_id: market_id.clone().into(),
+            },
         };
 
         let res: DerivativeMarketMidPriceAndTOBResponse = self.querier.query(&request.into())?;
         Ok(res)
     }
 
-    pub fn query_spot_market_mid_price_and_tob<T: Into<MarketId>>(&self, market_id: T) -> StdResult<SpotMarketMidPriceAndTOBResponse> {
+    pub fn query_spot_market_mid_price_and_tob<T: Into<MarketId> + Clone>(&self, market_id: &'a T) -> StdResult<SpotMarketMidPriceAndTOBResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
-            query_data: InjectiveQuery::SpotMarketMidPriceAndTob { market_id: market_id.into() },
+            query_data: InjectiveQuery::SpotMarketMidPriceAndTob {
+                market_id: market_id.clone().into(),
+            },
         };
 
         let res: SpotMarketMidPriceAndTOBResponse = self.querier.query(&request.into())?;
@@ -312,10 +325,10 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_token_factory_denom_total_supply<T: Into<String>>(&self, denom: T) -> StdResult<TokenFactoryDenomSupplyResponse> {
+    pub fn query_token_factory_denom_total_supply<T: Into<String> + Clone>(&self, denom: &'a T) -> StdResult<TokenFactoryDenomSupplyResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Tokenfactory,
-            query_data: InjectiveQuery::TokenFactoryDenomTotalSupply { denom: denom.into() },
+            query_data: InjectiveQuery::TokenFactoryDenomTotalSupply { denom: denom.clone().into() },
         };
 
         let res: TokenFactoryDenomSupplyResponse = self.querier.query(&request.into())?;

--- a/packages/injective-cosmwasm/src/querier.rs
+++ b/packages/injective-cosmwasm/src/querier.rs
@@ -170,20 +170,20 @@ impl<'a> InjectiveQuerier<'a> {
         &self,
         market_id: &'a T,
         subaccount_id: &'a P,
-        base_amount: &'a FPDecimal,
-        quote_amount: &'a FPDecimal,
+        base_amount: FPDecimal,
+        quote_amount: FPDecimal,
         strategy: i32,
-        reference_price: &'a Option<FPDecimal>,
+        reference_price: Option<FPDecimal>,
     ) -> StdResult<TraderSpotOrdersResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::TraderSpotOrdersToCancelUpToAmount {
                 market_id: market_id.clone().into(),
                 subaccount_id: subaccount_id.clone().into(),
-                base_amount: *base_amount,
-                quote_amount: *quote_amount,
+                base_amount,
+                quote_amount,
                 strategy,
-                reference_price: *reference_price,
+                reference_price,
             },
         };
 
@@ -195,18 +195,18 @@ impl<'a> InjectiveQuerier<'a> {
         &self,
         market_id: &'a T,
         subaccount_id: &'a P,
-        quote_amount: &'a FPDecimal,
+        quote_amount: FPDecimal,
         strategy: i32,
-        reference_price: &'a Option<FPDecimal>,
+        reference_price: Option<FPDecimal>,
     ) -> StdResult<TraderDerivativeOrdersResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::TraderDerivativeOrdersToCancelUpToAmount {
                 market_id: market_id.clone().into(),
                 subaccount_id: subaccount_id.clone().into(),
-                quote_amount: *quote_amount,
+                quote_amount,
                 strategy,
-                reference_price: *reference_price,
+                reference_price,
             },
         };
 

--- a/packages/injective-cosmwasm/src/querier.rs
+++ b/packages/injective-cosmwasm/src/querier.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use cosmwasm_std::{QuerierWrapper, StdResult};
 
 use injective_math::FPDecimal;
@@ -40,10 +42,12 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_derivative_market<T: Into<MarketId>>(&self, market_id: T) -> StdResult<DerivativeMarketResponse> {
+    pub fn query_derivative_market<T: Into<MarketId> + Clone>(&self, market_id: &'a T) -> StdResult<DerivativeMarketResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
-            query_data: InjectiveQuery::DerivativeMarket { market_id: market_id.into() },
+            query_data: InjectiveQuery::DerivativeMarket {
+                market_id: market_id.clone().into(),
+            },
         };
 
         let res: DerivativeMarketResponse = self.querier.query(&request.into())?;

--- a/packages/injective-cosmwasm/src/querier.rs
+++ b/packages/injective-cosmwasm/src/querier.rs
@@ -170,20 +170,20 @@ impl<'a> InjectiveQuerier<'a> {
         &self,
         market_id: &'a T,
         subaccount_id: &'a P,
-        base_amount: FPDecimal,
-        quote_amount: FPDecimal,
+        base_amount: &'a FPDecimal,
+        quote_amount: &'a FPDecimal,
         strategy: i32,
-        reference_price: Option<FPDecimal>,
+        reference_price: &'a Option<FPDecimal>,
     ) -> StdResult<TraderSpotOrdersResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::TraderSpotOrdersToCancelUpToAmount {
                 market_id: market_id.clone().into(),
                 subaccount_id: subaccount_id.clone().into(),
-                base_amount,
-                quote_amount,
+                base_amount: *base_amount,
+                quote_amount: *quote_amount,
                 strategy,
-                reference_price,
+                reference_price: *reference_price,
             },
         };
 
@@ -195,18 +195,18 @@ impl<'a> InjectiveQuerier<'a> {
         &self,
         market_id: &'a T,
         subaccount_id: &'a P,
-        quote_amount: FPDecimal,
+        quote_amount: &'a FPDecimal,
         strategy: i32,
-        reference_price: Option<FPDecimal>,
+        reference_price: &'a Option<FPDecimal>,
     ) -> StdResult<TraderDerivativeOrdersResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Exchange,
             query_data: InjectiveQuery::TraderDerivativeOrdersToCancelUpToAmount {
                 market_id: market_id.clone().into(),
                 subaccount_id: subaccount_id.clone().into(),
-                quote_amount,
+                quote_amount: *quote_amount,
                 strategy,
-                reference_price,
+                reference_price: *reference_price,
             },
         };
 
@@ -292,8 +292,8 @@ impl<'a> InjectiveQuerier<'a> {
 
     pub fn query_oracle_volatility(
         &self,
-        base_info: Option<OracleInfo>,
-        quote_info: Option<OracleInfo>,
+        base_info: &'a Option<OracleInfo>,
+        quote_info: &'a Option<OracleInfo>,
         max_age: u64,
         include_raw_history: bool,
         include_metadata: bool,
@@ -301,8 +301,8 @@ impl<'a> InjectiveQuerier<'a> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Oracle,
             query_data: InjectiveQuery::OracleVolatility {
-                base_info,
-                quote_info,
+                base_info: base_info.clone(),
+                quote_info: quote_info.clone(),
                 oracle_history_options: Some(OracleHistoryOptions {
                     max_age,
                     include_raw_history,
@@ -315,10 +315,14 @@ impl<'a> InjectiveQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_oracle_price(&self, oracle_type: OracleType, base: String, quote: String) -> StdResult<OraclePriceResponse> {
+    pub fn query_oracle_price(&self, oracle_type: &'a OracleType, base: &str, quote: &str) -> StdResult<OraclePriceResponse> {
         let request = InjectiveQueryWrapper {
             route: InjectiveRoute::Oracle,
-            query_data: InjectiveQuery::OraclePrice { oracle_type, base, quote },
+            query_data: InjectiveQuery::OraclePrice {
+                oracle_type: *oracle_type,
+                base: base.into(),
+                quote: quote.into(),
+            },
         };
 
         let res: OraclePriceResponse = self.querier.query(&request.into())?;

--- a/packages/injective-cosmwasm/src/subaccount.rs
+++ b/packages/injective-cosmwasm/src/subaccount.rs
@@ -38,12 +38,12 @@ pub fn addr_to_bech32(addr: String) -> String {
     bech32::encode("inj", encoded_bytes)
 }
 
-pub fn subaccount_id_to_ethereum_address(subaccount_id: SubaccountId) -> String {
+pub fn subaccount_id_to_ethereum_address(subaccount_id: &SubaccountId) -> String {
     let subaccount_id_str = subaccount_id.as_str();
     subaccount_id_str[0..subaccount_id_str.len() - 24].to_string()
 }
 
-pub fn subaccount_id_to_injective_address(subaccount_id: SubaccountId) -> String {
+pub fn subaccount_id_to_injective_address(subaccount_id: &SubaccountId) -> String {
     let ethereum_address = subaccount_id_to_ethereum_address(subaccount_id);
     addr_to_bech32(ethereum_address)
 }
@@ -79,7 +79,7 @@ mod tests {
     #[test]
     fn subaccount_id_to_address_test() {
         let subaccount_id = "0xb5e09b93aceb70c1711af078922fa256011d7e56000000000000000000000000";
-        let address = subaccount_id_to_injective_address(SubaccountId::new(subaccount_id.to_string()).expect("failed to create subaccount_id"));
+        let address = subaccount_id_to_injective_address(&SubaccountId::new(subaccount_id.to_string()).expect("failed to create subaccount_id"));
 
         assert_eq!(address, "inj1khsfhyavadcvzug67pufytaz2cq36ljkrsr0nv");
     }


### PR DESCRIPTION
* all queries now expect borrowed types
* but all helper messages that create various POJO structs still move variables (somehow it didn't feel right to clone them inside, and I preferred to be more explicit about their value consumption, if you see it otherwise do let me know and I'll change it)