### PR TITLE
Set protobuf-codegen lite_runtime option

### DIFF
--- a/packages/injective-protobuf/build.rs
+++ b/packages/injective-protobuf/build.rs
@@ -3,6 +3,7 @@ use protobuf_codegen_pure::Customize;
 fn main() {
     let customizer = Customize {
         gen_mod_rs: Some(true),
+        lite_runtime: Some(true),
         ..Default::default()
     };
 


### PR DESCRIPTION
#113 follow-up.

Setting this option reduces the size of the reference wasm from ~815KB to ~285 KB.

An acceptable ~2.5% increase now, over a parser with custom structs, and a ~10% increase over a tailor-made parser (i.e. without the `protofuf` crate).