### PR TITLE
chore: fix amount field type for MsgIncreasePositionMargin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "injective-std"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "injective-cosmwasm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "injective-std"
-version = "0.1.4"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "cosmwasm-std",
@@ -831,7 +831,7 @@ dependencies = [
  "base64",
  "cosmwasm-std",
  "cw-multi-test",
- "injective-cosmwasm 0.2.1",
+ "injective-cosmwasm 0.2.2",
  "rand 0.4.6",
  "secp256k1",
  "serde 1.0.163",

--- a/packages/injective-cosmwasm/Cargo.toml
+++ b/packages/injective-cosmwasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "injective-cosmwasm"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Albert Chon <albert@injectivelabs.org>", "Markus Waas <markus@injectivelabs.org>", "F Grabner <friedrich@injectivelabs.org>", "Bartek Tofel <bartek@injectivelabs.org>"]
 edition = "2018"
 description = "Bindings for CosmWasm contracts to call into custom modules of Injective Core"

--- a/packages/injective-cosmwasm/src/msg.rs
+++ b/packages/injective-cosmwasm/src/msg.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{Addr, BankMsg, Coin, CosmosMsg, CustomMsg, Deps, StdError, StdResult};
+use injective_math::FPDecimal;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -79,7 +80,7 @@ pub enum InjectiveMsg {
         source_subaccount_id: SubaccountId,
         destination_subaccount_id: SubaccountId,
         market_id: MarketId,
-        amount: Coin,
+        amount: FPDecimal,
     },
     LiquidatePosition {
         sender: Addr,
@@ -295,7 +296,7 @@ pub fn create_increase_position_margin_msg(
     source_subaccount_id: SubaccountId,
     destination_subaccount_id: SubaccountId,
     market_id: MarketId,
-    amount: Coin,
+    amount: FPDecimal,
 ) -> CosmosMsg<InjectiveMsgWrapper> {
     InjectiveMsgWrapper {
         route: InjectiveRoute::Exchange,

--- a/packages/injective-std/Cargo.toml
+++ b/packages/injective-std/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 name = "injective-std"
 repository = "https://github.com/InjectiveLabs/cw-injective/tree/master/packages/injective-std"
-version = "0.1.4"
+version = "0.1.3"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/injective-std/Cargo.toml
+++ b/packages/injective-std/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 name = "injective-std"
 repository = "https://github.com/InjectiveLabs/cw-injective/tree/master/packages/injective-std"
-version = "0.1.3"
+version = "0.1.4"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Amount doesn't have coin type on chain-side, but `sdk.Dec` so should be represented as `FPDecimal`.

Also, maybe we should use this PR to check if other message have correct types for decimal amounts?