### PR TITLE
fix: deserialize string shortSubaccount to hex

### DIFF
--- a/packages/injective-cosmwasm/src/exchange/types.rs
+++ b/packages/injective-cosmwasm/src/exchange/types.rs
@@ -274,7 +274,7 @@ impl<'de> Deserialize<'de> for ShortSubaccountId {
         let id = String::deserialize(deserializer)?;
 
         match id.parse::<u16>() {
-            Ok(value) if value <= MAX_SHORT_SUBACCOUNT_NONCE => Ok(ShortSubaccountId::unchecked(format!("{:x}", value))),
+            Ok(value) if value <= MAX_SHORT_SUBACCOUNT_NONCE => Ok(ShortSubaccountId::unchecked(format!("{:03x}", value))),
             _ => {
                 let maybe_long = SubaccountId::unchecked(id);
                 let maybe_short: ShortSubaccountId = ShortSubaccountId::from(maybe_long);

--- a/packages/injective-cosmwasm/src/exchange/types.rs
+++ b/packages/injective-cosmwasm/src/exchange/types.rs
@@ -683,14 +683,14 @@ mod tests {
 
     #[test]
     fn short_subaccount_id_can_be_deserialized_from_valid_short_decimal() {
-        let short_subaccount = ShortSubaccountId::unchecked("1");
-        assert_de_tokens(&short_subaccount, &[Token::Str("001")]);
+        let short_subaccount = ShortSubaccountId::unchecked("001");
+        assert_de_tokens(&short_subaccount, &[Token::Str("1")]);
     }
 
     #[test]
     fn short_subaccount_id_can_be_deserialized_from_valid_long_decimal() {
-        let short_subaccount = ShortSubaccountId::unchecked("010");
-        assert_de_tokens(&short_subaccount, &[Token::Str("00a")]);
+        let short_subaccount = ShortSubaccountId::unchecked("00a");
+        assert_de_tokens(&short_subaccount, &[Token::Str("010")]);
     }
 
     #[test]
@@ -728,8 +728,8 @@ mod tests {
 
     #[test]
     fn short_subaccount_id_can_be_deserialized_from_valid_highest_decimal_short_subaccount_id() {
-        let short_subaccount = ShortSubaccountId::unchecked("999");
-        assert_de_tokens(&short_subaccount, &[Token::Str("3e7")]);
+        let short_subaccount = ShortSubaccountId::unchecked("3e7");
+        assert_de_tokens(&short_subaccount, &[Token::Str("999")]);
     }
 
     #[test]

--- a/packages/injective-cosmwasm/src/exchange/types.rs
+++ b/packages/injective-cosmwasm/src/exchange/types.rs
@@ -274,7 +274,7 @@ impl<'de> Deserialize<'de> for ShortSubaccountId {
         let id = String::deserialize(deserializer)?;
 
         match id.parse::<u16>() {
-            Ok(value) if value <= MAX_SHORT_SUBACCOUNT_NONCE => Ok(ShortSubaccountId::unchecked(id)),
+            Ok(value) if value <= MAX_SHORT_SUBACCOUNT_NONCE => Ok(ShortSubaccountId::unchecked(format!("{:x}", value))),
             _ => {
                 let maybe_long = SubaccountId::unchecked(id);
                 let maybe_short: ShortSubaccountId = ShortSubaccountId::from(maybe_long);

--- a/packages/injective-cosmwasm/src/exchange/types.rs
+++ b/packages/injective-cosmwasm/src/exchange/types.rs
@@ -684,7 +684,7 @@ mod tests {
     #[test]
     fn short_subaccount_id_can_be_deserialized_from_valid_short_decimal() {
         let short_subaccount = ShortSubaccountId::unchecked("1");
-        assert_de_tokens(&short_subaccount, &[Token::Str("1")]);
+        assert_de_tokens(&short_subaccount, &[Token::Str("001")]);
     }
 
     #[test]

--- a/packages/injective-cosmwasm/src/exchange/types.rs
+++ b/packages/injective-cosmwasm/src/exchange/types.rs
@@ -690,7 +690,7 @@ mod tests {
     #[test]
     fn short_subaccount_id_can_be_deserialized_from_valid_long_decimal() {
         let short_subaccount = ShortSubaccountId::unchecked("010");
-        assert_de_tokens(&short_subaccount, &[Token::Str("010")]);
+        assert_de_tokens(&short_subaccount, &[Token::Str("00a")]);
     }
 
     #[test]
@@ -729,7 +729,7 @@ mod tests {
     #[test]
     fn short_subaccount_id_can_be_deserialized_from_valid_highest_decimal_short_subaccount_id() {
         let short_subaccount = ShortSubaccountId::unchecked("999");
-        assert_de_tokens(&short_subaccount, &[Token::Str("999")]);
+        assert_de_tokens(&short_subaccount, &[Token::Str("3e7")]);
     }
 
     #[test]


### PR DESCRIPTION
The current serialization and deserialization of ShortSubaccountId is not paired, let's do quick example:

subaccountID: 
0x5e249f0e8cb406f41de16e1bd6f6b55e7bc75add000000000000000000000014 -> short: '014' -> serialized: '020' -> deserialized: '020', then serialized the deserialized version, we got '032', while it should be 14

# Changes

- Convert subaccount number to hex after validation + tests updated