### PR TITLE
add round to FPDecimal, fix a bug in must_from_str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
  "cw-storage-plus 0.15.1",
  "ethereum-types",
  "hex",
- "injective-math 0.1.20",
+ "injective-math 0.1.21",
  "schemars",
  "serde 1.0.164",
  "serde-json-wasm 0.4.1",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "injective-math"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "bigint",
  "cosmwasm-schema",
@@ -840,7 +840,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "injective-cosmwasm 0.2.12",
- "injective-math 0.1.20",
+ "injective-math 0.1.21",
  "rand 0.4.6",
  "secp256k1",
  "serde 1.0.164",

--- a/packages/injective-math/Cargo.toml
+++ b/packages/injective-math/Cargo.toml
@@ -6,7 +6,7 @@ license     = "Apache-2.0"
 name        = "injective-math"
 readme      = "README.md"
 repository  = "https://github.com/InjectiveLabs/cw-injective/tree/master/packages/injective-math"
-version     = "0.1.20"
+version     = "0.1.21"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/injective-math/src/fp_decimal/from_str.rs
+++ b/packages/injective-math/src/fp_decimal/from_str.rs
@@ -45,7 +45,12 @@ impl FromStr for FPDecimal {
 
 impl FPDecimal {
     pub fn must_from_str(input: &str) -> Self {
-        Self::from_str(input).unwrap()
+        let i = Self::from_str(input).unwrap();
+        // to handle must_from_str("-0")
+        if i.num == U256([0, 0, 0, 0]) {
+            return FPDecimal::ZERO;
+        }
+        i
     }
 }
 

--- a/packages/injective-math/src/fp_decimal/round.rs
+++ b/packages/injective-math/src/fp_decimal/round.rs
@@ -1,0 +1,3 @@
+use crate::fp_decimal::{FPDecimal, U256};
+use std::iter;
+use std::ops;

--- a/packages/injective-math/src/utils.rs
+++ b/packages/injective-math/src/utils.rs
@@ -102,16 +102,6 @@ pub fn round(num: FPDecimal, min_tick: FPDecimal) -> FPDecimal {
         }
         Ordering::Greater => num_floor + min_tick,
     }
-    // if diff < (min_tick / FPDecimal::TWO) {
-    //     num_floor
-    // } else if diff > (min_tick / FPDecimal::TWO) {
-    //     num_floor + min_tick
-    // } else {
-    //     if num_floor / (min_tick * FPDecimal::TWO) == FPDecimal::ZERO {
-    //         return num_floor;
-    //     }
-    //     return num_floor + min_tick;
-    // }
 }
 
 pub fn round_to_min_tick(num: FPDecimal, min_tick: FPDecimal) -> FPDecimal {

--- a/packages/injective-math/src/utils.rs
+++ b/packages/injective-math/src/utils.rs
@@ -143,6 +143,7 @@ pub fn round_up_to_min_tick(num: FPDecimal, min_tick: FPDecimal) -> FPDecimal {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fp_decimal::scale::Scaled;
 
     #[test]
     fn test_floor() {
@@ -184,15 +185,25 @@ mod tests {
 
     #[test]
     fn test_round() {
+        assert_eq!(round(FPDecimal::must_from_str("0.13"), FPDecimal::ONE), FPDecimal::ZERO);
+        assert_eq!(round(FPDecimal::must_from_str("0.49"), FPDecimal::ONE), FPDecimal::ZERO);
+        assert_eq!(round(FPDecimal::must_from_str("0.5"), FPDecimal::ONE), FPDecimal::ZERO);
+        assert_eq!(round(FPDecimal::must_from_str("0.50009"), FPDecimal::ONE), FPDecimal::ONE);
+
+        assert_eq!(round(FPDecimal::must_from_str("-0.13"), FPDecimal::ONE), FPDecimal::ZERO);
+        assert_eq!(round(FPDecimal::must_from_str("-0.49"), FPDecimal::ONE), FPDecimal::ZERO);
+        assert_eq!(round(FPDecimal::must_from_str("-0.5"), FPDecimal::ONE), FPDecimal::ZERO);
+        assert_eq!(round(FPDecimal::must_from_str("-0.51"), FPDecimal::ONE), -FPDecimal::ONE);
+        assert_eq!(round(FPDecimal::must_from_str("-1.50009"), FPDecimal::ONE), -FPDecimal::TWO);
+    }
+
+    #[test]
+    fn test_round_with_scaled_numbers() {
         assert_eq!(round(FPDecimal::must_from_str("0"), FPDecimal::must_from_str("0.1")), FPDecimal::ZERO);
         assert_eq!(
             round(FPDecimal::must_from_str("0.13"), FPDecimal::must_from_str("0.1")),
             FPDecimal::must_from_str("0.1")
         );
-        assert_eq!(round(FPDecimal::must_from_str("0.13"), FPDecimal::ONE), FPDecimal::ZERO);
-        assert_eq!(round(FPDecimal::must_from_str("0.49"), FPDecimal::ONE), FPDecimal::ZERO);
-        assert_eq!(round(FPDecimal::must_from_str("0.5"), FPDecimal::ONE), FPDecimal::ZERO);
-        assert_eq!(round(FPDecimal::must_from_str("0.50009"), FPDecimal::ONE), FPDecimal::ONE);
         assert_eq!(
             round(FPDecimal::must_from_str("0.50009"), FPDecimal::must_from_str("0.0001")),
             FPDecimal::must_from_str("0.5001")
@@ -203,15 +214,21 @@ mod tests {
             round(FPDecimal::must_from_str("-0.13"), FPDecimal::must_from_str("0.1")),
             FPDecimal::must_from_str("-0.1")
         );
-        assert_eq!(round(FPDecimal::must_from_str("-0.13"), FPDecimal::ONE), FPDecimal::ZERO);
-        assert_eq!(round(FPDecimal::must_from_str("-0.49"), FPDecimal::ONE), FPDecimal::ZERO);
-        assert_eq!(round(FPDecimal::must_from_str("-0.5"), FPDecimal::ONE), FPDecimal::ZERO);
-        assert_eq!(round(FPDecimal::must_from_str("-0.51"), FPDecimal::ONE), -FPDecimal::ONE);
         assert_eq!(
             round(FPDecimal::must_from_str("-0.50009"), FPDecimal::must_from_str("0.0001")),
             FPDecimal::must_from_str("-0.5001")
         );
-        assert_eq!(round(FPDecimal::must_from_str("-1.50009"), FPDecimal::ONE), -FPDecimal::TWO);
+
+        assert_eq!(round(FPDecimal::must_from_str("-1.50009"), FPDecimal::ONE.scaled(1)), FPDecimal::ZERO);
+        assert_eq!(
+            round(FPDecimal::must_from_str("-1.50009").scaled(1), FPDecimal::ONE.scaled(1)),
+            -FPDecimal::TWO.scaled(1)
+        );
+        assert_eq!(round(FPDecimal::must_from_str("-1.50009"), FPDecimal::ONE.scaled(1)), FPDecimal::ZERO);
+        assert_eq!(
+            round(FPDecimal::must_from_str("-1.50009").scaled(1), FPDecimal::ONE.scaled(1)),
+            -FPDecimal::TWO.scaled(1)
+        );
     }
 
     #[test]

--- a/packages/injective-math/src/utils.rs
+++ b/packages/injective-math/src/utils.rs
@@ -1,6 +1,7 @@
 use crate::FPDecimal;
 use bigint::U256;
 use cosmwasm_std::StdError;
+use std::cmp::Ordering;
 use std::{fmt::Display, str::FromStr};
 
 #[derive(Default)]
@@ -90,15 +91,27 @@ pub fn round(num: FPDecimal, min_tick: FPDecimal) -> FPDecimal {
     //FIXME min_tick has to be 1, 0.1,0.01, etc
     let num_floor = floor(num, min_tick);
     let diff = num - num_floor;
-    if diff < (min_tick / FPDecimal::TWO) {
-        return num_floor;
-    } else if diff > (min_tick / FPDecimal::TWO) {
-        return num_floor + min_tick;
+    match diff.cmp(&(min_tick / FPDecimal::TWO)) {
+        Ordering::Less => num_floor,
+        Ordering::Equal => {
+            if num_floor / (min_tick * FPDecimal::TWO) == FPDecimal::ZERO {
+                num_floor
+            } else {
+                num_floor + min_tick
+            }
+        }
+        Ordering::Greater => num_floor + min_tick,
     }
-    if num_floor / (min_tick * FPDecimal::TWO) == FPDecimal::ZERO {
-        return num_floor;
-    }
-    return num_floor + min_tick;
+    // if diff < (min_tick / FPDecimal::TWO) {
+    //     num_floor
+    // } else if diff > (min_tick / FPDecimal::TWO) {
+    //     num_floor + min_tick
+    // } else {
+    //     if num_floor / (min_tick * FPDecimal::TWO) == FPDecimal::ZERO {
+    //         return num_floor;
+    //     }
+    //     return num_floor + min_tick;
+    // }
 }
 
 pub fn round_to_min_tick(num: FPDecimal, min_tick: FPDecimal) -> FPDecimal {

--- a/packages/injective-math/src/utils.rs
+++ b/packages/injective-math/src/utils.rs
@@ -78,7 +78,6 @@ pub fn div_dec(num: FPDecimal, denom: FPDecimal) -> FPDecimal {
 
 pub fn floor(num: FPDecimal, min_tick: FPDecimal) -> FPDecimal {
     // min_tick has to be a positive number
-    //FIXME min_tick has to be 1, 0.1,0.01, etc
     assert!(min_tick >= FPDecimal::ZERO);
     if num.is_zero() {
         return num;
@@ -88,7 +87,6 @@ pub fn floor(num: FPDecimal, min_tick: FPDecimal) -> FPDecimal {
 }
 
 pub fn round(num: FPDecimal, min_tick: FPDecimal) -> FPDecimal {
-    //FIXME min_tick has to be 1, 0.1,0.01, etc
     let num_floor = floor(num, min_tick);
     let diff = num - num_floor;
     match diff.cmp(&(min_tick / FPDecimal::TWO)) {


### PR DESCRIPTION
1. Add round to FPDecimal
2. FPDecimal::must_from_str("-0") returns FPDeciaml::ZERO.