### PR TITLE
Chore/unified rust edition to 2021

### DIFF
--- a/contracts/dummy/Cargo.toml
+++ b/contracts/dummy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dummy"
 version = "1.0.0"
 authors = ["Bartek Tofel <tofel.b@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.

--- a/packages/injective-cosmwasm/Cargo.toml
+++ b/packages/injective-cosmwasm/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
  "Markus Waas <markus@injectivelabs.org>",
 ]
 description = "Bindings for CosmWasm contracts to call into custom modules of Injective Core"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 name = "injective-cosmwasm"
 readme = "README.md"

--- a/packages/injective-math/Cargo.toml
+++ b/packages/injective-math/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors     = [ "Markus Waas <markus@injectivelabs.org>" ]
 description = "Math library for CosmWasm contracts in Injective Protocol"
-edition     = "2018"
+edition     = "2021"
 license     = "Apache-2.0"
 name        = "injective-math"
 readme      = "README.md"

--- a/packages/injective-protobuf/Cargo.toml
+++ b/packages/injective-protobuf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "injective-protobuf"
 version = "0.2.1"
 authors = ["Mauro Lacy <mauro@lacy.com.es>"]
-edition = "2018"
+edition = "2021"
 description = "Protobug parsing for Injective Protocol"
 repository = "https://github.com/InjectiveLabs/cw-injective/tree/master/packages/injective-protobuf"
 license = "Apache-2.0"


### PR DESCRIPTION
https://github.com/CosmWasm/cosmwasm/blob/88762e8a9a34e63ebc2d091752eef5dc106a3bc2/CHANGELOG-pre1.0.0.md

cosmwasm has set rust-edition to 2021, so it probably ok for us to set edition to 2021 for all our packages and contracts