### PR TITLE
Add `From<FPDecimal> for Uint256` for FPDecimal

### DIFF
--- a/packages/injective-math/src/fp_decimal/mod.rs
+++ b/packages/injective-math/src/fp_decimal/mod.rs
@@ -463,6 +463,18 @@ mod tests {
     }
 
     #[test]
+    fn test_into_u256() {
+        let fp_decimal: Uint256 = FPDecimal {
+            num: U256::from(12345u64),
+            sign: 1, // Assuming it's always positive
+        }
+        .into();
+        let u256 = Uint256::from(12345u64);
+
+        assert_eq!(u256, fp_decimal)
+    }
+
+    #[test]
     fn into_uint256_floor() {
         let fp_decimal = FPDecimal {
             num: U256::from_dec_str("12345").unwrap(),

--- a/packages/injective-math/src/fp_decimal/mod.rs
+++ b/packages/injective-math/src/fp_decimal/mod.rs
@@ -72,6 +72,12 @@ impl From<Uint128> for FPDecimal {
     }
 }
 
+impl From<FPDecimal> for Uint256 {
+    fn from(value: FPDecimal) -> Self {
+        value.to_u256()
+    }
+}
+
 impl From<Uint256> for FPDecimal {
     fn from(x: Uint256) -> FPDecimal {
         FPDecimal::from_str(&x.to_string()).unwrap()


### PR DESCRIPTION
Closes #216 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled conversion from `FPDecimal` to `Uint256` for improved compatibility.
  
- **Tests**
  - Added tests to ensure accurate conversion from `FPDecimal` to `Uint256`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->