### PR TITLE
Fix: added default-features = false on chrono dependency

### DIFF
--- a/packages/injective-std/Cargo.toml
+++ b/packages/injective-std/Cargo.toml
@@ -10,7 +10,7 @@ version     = "1.12.10-testnet"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono             = { version = "0.4.24" }
+chrono             = { version = "0.4.24", default-features = false }
 cosmwasm-std       = { version = "1.5.0", features = [ "abort", "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "iterator", "stargate" ] }
 osmosis-std-derive = { version = "0.20.1" }
 prost              = { version = "0.12.3" }


### PR DESCRIPTION
By adding `injective-std` as a dependency to a smart contract, the following error was generated when trying to store the code on-chain:

```
Error: failed to execute message; message index: 0: Error calling the VM: Error during static Wasm validation: Wasm contract requires unsupported import: "__wbindgen_placeholder__.__wbindgen_describe".
```

This occurred because the [**chrono**](https://docs.rs/chrono/latest/chrono/) dependency was not imported with `default-feature = false`.








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the `chrono` dependency to disable default features, enhancing customization and potentially reducing the package size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->