### PR TITLE
bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "injective-std"
-version = "1.12.10-testnet"
+version = "1.12.10-testnet-rc1"
 dependencies = [
  "chrono",
  "cosmwasm-std",

--- a/packages/injective-std/Cargo.toml
+++ b/packages/injective-std/Cargo.toml
@@ -5,7 +5,7 @@ license     = "MIT OR Apache-2.0"
 name        = "injective-std"
 readme      = "README.md"
 repository  = "https://github.com/InjectiveLabs/cw-injective/tree/dev/packages/injective-std"
-version     = "1.12.10-testnet"
+version     = "1.12.10-testnet-rc1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version number for the `injective-std` package to "1.12.10-testnet-rc1".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->