### PR TITLE
Upgrade prost to 0.13.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
  "injective-cosmwasm 0.3.1",
  "injective-math 0.3.0",
  "injective-std 1.13.2-auction",
- "prost 0.12.6",
+ "prost 0.13.4",
  "schemars",
  "serde 1.0.210",
  "thiserror",
@@ -826,7 +826,7 @@ dependencies = [
  "cw-utils",
  "derivative",
  "itertools 0.13.0",
- "prost 0.13.3",
+ "prost 0.13.4",
  "schemars",
  "serde 1.0.210",
  "sha2 0.10.8",
@@ -1622,7 +1622,7 @@ dependencies = [
  "injective-std 1.13.2-auction",
  "injective-test-tube",
  "injective-testing",
- "prost 0.12.6",
+ "prost 0.13.4",
  "schemars",
  "serde 1.0.210",
  "thiserror",
@@ -1643,7 +1643,7 @@ dependencies = [
  "injective-std 1.13.2-auction",
  "injective-test-tube",
  "injective-testing",
- "prost 0.12.6",
+ "prost 0.13.4",
  "schemars",
  "serde 1.0.210",
  "serde_json 1.0.128",
@@ -1700,8 +1700,8 @@ dependencies = [
  "chrono",
  "cosmwasm-std 2.1.4",
  "injective-std-derive 1.13.0",
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prost 0.13.4",
+ "prost-types 0.13.4",
  "schemars",
  "serde 1.0.210",
  "serde-cw-value",
@@ -1714,7 +1714,7 @@ dependencies = [
  "cosmwasm-std 2.1.4",
  "itertools 0.10.5",
  "proc-macro2",
- "prost 0.12.6",
+ "prost 0.13.4",
  "quote",
  "serde 1.0.210",
  "syn 1.0.109",
@@ -1766,7 +1766,7 @@ dependencies = [
  "injective-math 0.3.0",
  "injective-std 1.13.2-auction",
  "injective-test-tube",
- "prost 0.12.6",
+ "prost 0.13.4",
  "rand 0.4.6",
  "secp256k1",
  "serde 1.0.210",
@@ -2237,12 +2237,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
- "prost-derive 0.13.3",
+ "prost-derive 0.13.4",
 ]
 
 [[package]]
@@ -2273,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -2300,6 +2300,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+dependencies = [
+ "prost 0.13.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ injective-testing    = { version = "1.1.0", path = "./packages/injective-testing
 itertools            = { version = "0.10.3" }
 primitive-types      = { version = "0.12.2", default-features = false }
 proc-macro2          = { version = "1.0.40" }
-prost                = { version = "0.12.6" }
-prost-types          = { version = "0.12.6", default-features = false }
+prost                = { version = "0.13.4" }
+prost-types          = { version = "0.13.4", default-features = false }
 quote                = { version = "1.0.20" }
 rand                 = { version = "0.4.6" }
 schemars             = { version = "0.8.16" }


### PR DESCRIPTION
Uprade prost to 0.13.4 so that we can use this crate together with other crates which use latest prost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependencies `prost` and `prost-types` to version 0.13.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->