### PR TITLE
feat: upgrade chain dependencies to 1.19

### DIFF
--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           target: wasm32-unknown-unknown
           override: true
 
@@ -26,7 +26,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           args: --workspace --all-targets --locked
         env:
           RUST_BACKTRACE: 1
@@ -57,14 +57,14 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           target: wasm32-unknown-unknown
           override: true
       - name: Run all integration tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           args: --workspace --all-targets --locked --features=integration
         env:
           RUST_BACKTRACE: 1
@@ -81,7 +81,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           override: true
           components: rustfmt, clippy
 
@@ -89,12 +89,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           args: --all -- --check
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           args: -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,8 +204,8 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
  "cw2",
- "injective-cosmwasm 0.3.5-1",
- "injective-math 0.3.5-1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "injective-cosmwasm 0.3.6",
+ "injective-math 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "injective-std",
  "prost 0.13.5",
  "schemars 0.8.22",
@@ -540,15 +540,15 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.2"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b0a718b13ffe224e32a8c1f68527354868f47d6cc84afe8c66cb05fbb3ced6e"
+checksum = "bb372d91a06c6ad130559c9028048c92a557ec4f466b00a49cbd5e79f5e2880b"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.2"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c08dd7585b5c48fbcb947ada7a3fb49465fb735481ed295b54ca98add6dc17f"
+checksum = "5c1731c775eb882e6cc3f295e0b91f32c9f7e40b6c1157d04029dd781bbe5b4d"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.2"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5677eed823a61eeb615b1ad4915a42336b70b0fe3f87bf3da4b59f3dcf9034af"
+checksum = "5a453265d2883bece23abac6b8fe1cc85b130d0ef8a70c842c1731a5647d8e39"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.2"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4881104f54871bcea6f30757bee13b7f09c0998d1b0de133cce5a52336a2ada"
+checksum = "5420f6d4181383fe5894609f8dfa54ce4c494ae8fafe5d30eaa7516ee984bdc8"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -776,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.2"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f335d3f51e10260f4dfb0840f0526c1d25c6b42a9489c04ce41ed9aa54dd6d"
+checksum = "03fdbf30558ff380a9555b508b3b68f60ab205cb93c6f34de2bfef27ee5eeee5"
 dependencies = [
  "cw-schema-derive",
  "indexmap 2.9.0",
@@ -791,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.2"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba2eb93f854caeacc5eda13d15663b7605395514fd378bfba8e7532f1fc5865"
+checksum = "a978316851c7855bacb73844c71d1d9ab5f999b7c75fe0863042d61f721d3b99"
 dependencies = [
  "heck",
  "itertools 0.13.0",
@@ -956,7 +956,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
  "cw2",
- "injective-cosmwasm 0.3.5-1",
+ "injective-cosmwasm 0.3.6",
  "injective-std",
  "schemars 0.8.22",
  "serde",
@@ -1646,7 +1646,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
 dependencies = [
- "rlp",
+ "rlp 0.4.6",
 ]
 
 [[package]]
@@ -1686,13 +1686,13 @@ dependencies = [
 
 [[package]]
 name = "injective-cosmwasm"
-version = "0.3.5-1"
+version = "0.3.6"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
  "ethereum-types",
  "hex",
- "injective-math 0.3.5-1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "injective-math 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars 0.8.22",
  "serde",
  "serde-json-wasm",
@@ -1704,15 +1704,15 @@ dependencies = [
 
 [[package]]
 name = "injective-cosmwasm"
-version = "0.3.5-1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31826fd53ec0974040d31a31d54e78e1295aa36a20a429619df58ce48dee1d5e"
+checksum = "2f0fc1345be5ca8c1bf7bcc7215b581cbef6a13a73e62fa390dc2be122183363"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
  "ethereum-types",
  "hex",
- "injective-math 0.3.5-1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "injective-math 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars 0.8.22",
  "serde",
  "serde_repr",
@@ -1730,8 +1730,8 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
  "cw2",
- "injective-cosmwasm 0.3.5-1",
- "injective-math 0.3.5-1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "injective-cosmwasm 0.3.6",
+ "injective-math 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "injective-std",
  "injective-test-tube",
  "injective-testing",
@@ -1752,8 +1752,8 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
  "cw2",
- "injective-cosmwasm 0.3.5-1",
- "injective-math 0.3.5-1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "injective-cosmwasm 0.3.6",
+ "injective-math 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "injective-std",
  "injective-test-tube",
  "injective-testing",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "injective-math"
-version = "0.3.5-1"
+version = "0.3.6"
 dependencies = [
  "cosmwasm-std",
  "primitive-types",
@@ -1776,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "injective-math"
-version = "0.3.5-1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e94be76fc9b92dcfa765455810052d1e6107fa07c218b7a3a9795cae45c4c7"
+checksum = "c04b6ee8f956b14b48b554acb8c70389f7ef614b8f1cdab9c1b8e87651ff8c8b"
 dependencies = [
  "cosmwasm-std",
  "primitive-types",
@@ -1788,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "injective-std"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7077c77e10aa48853d215c070f44016315a7a75ad9cc48a3bd0341cc7a12f3"
+checksum = "2313d53947ef805df990c67ff94ffa7b2eb02b1f8bdb5ff01539419bb1f0d736"
 dependencies = [
  "chrono",
  "cosmwasm-std",
@@ -1817,30 +1817,33 @@ dependencies = [
 
 [[package]]
 name = "injective-test-tube"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e73d64f4bccff07bbcac0b125100fbce05faf482817ab3bfa09647ccfdf6262"
+checksum = "c252988f42118daef1844725f4b46ed2591b544b909401ec34407c349122b324"
 dependencies = [
  "bindgen",
  "cosmrs",
  "cosmwasm-std",
- "injective-cosmwasm 0.3.5-1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "injective-cosmwasm 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "injective-std",
+ "k256",
  "prost 0.13.5",
+ "rlp 0.5.2",
  "serde",
  "serde_json",
+ "sha3",
  "test-tube-inj",
 ]
 
 [[package]]
 name = "injective-testing"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cw-multi-test",
- "injective-cosmwasm 0.3.5-1 (registry+https://github.com/rust-lang/crates.io-index)",
- "injective-math 0.3.5-1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "injective-cosmwasm 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "injective-math 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "injective-std",
  "injective-test-tube",
  "prost 0.13.5",
@@ -1926,7 +1929,18 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "once_cell",
  "sha2 0.10.9",
+ "signature",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -2591,6 +2605,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,6 +3057,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,15 +3374,17 @@ dependencies = [
 
 [[package]]
 name = "test-tube-inj"
-version = "2.0.9-1"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae6ff129d55b258b043dd6131aca68b458904892fac2cecd7bfa0f369304663"
+checksum = "36156086ca5edd5da0d000432782a6818e9db8da4d97b1d7717304e543388c5f"
 dependencies = [
  "base64 0.21.7",
  "cosmrs",
  "cosmwasm-std",
+ "k256",
  "prost 0.13.5",
  "serde_json",
+ "sha3",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ anyhow              = { version = "1.0.66" }
 base64              = { version = "0.21.5" }
 cosmos-sdk-proto    = { version = "0.20.0", default-features = false }
 cosmwasm-schema     = { version = "1.5.0" }
-cosmwasm-std        = { version = "3.0.2", features = [ "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "cosmwasm_2_0", "iterator", "stargate" ] }
+cosmwasm-std        = { version = "3.0.5", features = [ "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "cosmwasm_2_0", "iterator", "stargate" ] }
 cw-multi-test       = { version = "3.0.0" }
 cw-storage-plus     = { version = "3.0.1" }
 cw2                 = { version = "3.0.0" }
 ethereum-types      = { version = "0.5.2" }
 hex                 = { version = "0.4.3", features = [ "serde" ] }
-injective-cosmwasm  = { version = "0.3.5-1" }
-injective-math      = { version = "0.3.5-1" }
-injective-std       = { version = "1.18.0" }
-injective-test-tube = { version = "1.18.0" }
-injective-testing   = { path = "./packages/injective-testing" }
+injective-cosmwasm  = { version = "0.3.6" }
+injective-math      = { version = "0.3.6" }
+injective-std       = { version = "1.19.0" }
+injective-test-tube = { version = "1.19.0" }
+injective-testing   = { version = "1.19.0", path = "./packages/injective-testing" }
 primitive-types     = { version = "0.12.2", default-features = false }
 prost               = { version = "0.13.5", features = [ "prost-derive" ] }
 rand                = { version = "0.4.6" }
@@ -47,9 +47,3 @@ opt-level        = 3
 overflow-checks  = true
 panic            = 'abort'
 rpath            = false
-
-[patch.crates-io]
-# injective-cosmwasm = { path = "./packages/injective-cosmwasm" }
-# injective-math     = { path = "./packages/injective-math" }
-# injective-protobuf = { path = "./packages/injective-protobuf" }
-# injective-testing  = { path = "./packages/injective-testing" }

--- a/contracts/atomic-order-example/Cargo.toml
+++ b/contracts/atomic-order-example/Cargo.toml
@@ -31,7 +31,7 @@ cosmwasm-std       = { workspace = true }
 cw-storage-plus    = { workspace = true }
 cw2                = { workspace = true }
 injective-cosmwasm = { path = "../../packages/injective-cosmwasm" }
-injective-math  = { version = "0.3.5-1"}
+injective-math      = { version = "0.3.6" }
 injective-std      = { workspace = true }
 prost              = { workspace = true }
 schemars           = { workspace = true }

--- a/contracts/injective-cosmwasm-mock/Cargo.toml
+++ b/contracts/injective-cosmwasm-mock/Cargo.toml
@@ -28,7 +28,7 @@ cosmwasm-std       = { workspace = true }
 cw-storage-plus    = { workspace = true }
 cw2                = { workspace = true }
 injective-cosmwasm = { path = "../../packages/injective-cosmwasm" }
-injective-math     = { version = "0.3.5-1"}
+injective-math     = { version = "0.3.6" }
 injective-std      = { workspace = true }
 prost              = { workspace = true }
 schemars           = { workspace = true }

--- a/contracts/injective-cosmwasm-mock/src/utils.rs
+++ b/contracts/injective-cosmwasm-mock/src/utils.rs
@@ -728,7 +728,6 @@ pub fn set_address_of_pyth_contract(app: &InjectiveTestApp, validator: &SigningA
             params: Some(Params {
                 pyth_contract: pyth_address.address(),
                 chainlink_verifier_proxy_contract: "".to_string(),
-                accept_unverified_chainlink_data_streams_reports: true,
                 chainlink_data_streams_verification_gas_limit: 1000000,
             }),
         },

--- a/contracts/injective-cosmwasm-stargate-example/Cargo.toml
+++ b/contracts/injective-cosmwasm-stargate-example/Cargo.toml
@@ -28,7 +28,7 @@ cosmwasm-std       = { workspace = true }
 cw-storage-plus    = { workspace = true }
 cw2                = { workspace = true }
 injective-cosmwasm = { path = "../../packages/injective-cosmwasm" }
-injective-math     = { version = "0.3.5-1"}
+injective-math     = { version = "0.3.6" }
 injective-std      = { workspace = true }
 prost              = { workspace = true }
 schemars           = { workspace = true }

--- a/contracts/injective-cosmwasm-stargate-example/src/query.rs
+++ b/contracts/injective-cosmwasm-stargate-example/src/query.rs
@@ -11,11 +11,11 @@ pub fn handle_query_stargate_raw(querier: &QuerierWrapper<InjectiveQueryWrapper>
 
     #[allow(deprecated)]
     let request = &QueryRequest::<InjectiveQueryWrapper>::Stargate { path, data };
-    let raw = to_json_vec(request).map_err(|serialize_err| StdError::msg(format!("Serializing QueryRequest: {}", serialize_err)))?;
+    let raw = to_json_vec(request).map_err(|serialize_err| StdError::msg(format!("Serializing QueryRequest: {serialize_err}")))?;
 
     let value = match querier.raw_query(&raw) {
-        SystemResult::Err(system_err) => Err(StdError::msg(format!("Querier system error: {}", system_err))),
-        SystemResult::Ok(ContractResult::Err(contract_err)) => Err(StdError::msg(format!("Querier contract error: {}", contract_err))),
+        SystemResult::Err(system_err) => Err(StdError::msg(format!("Querier system error: {system_err}"))),
+        SystemResult::Ok(ContractResult::Err(contract_err)) => Err(StdError::msg(format!("Querier contract error: {contract_err}"))),
         SystemResult::Ok(ContractResult::Ok(value)) => Ok(value),
     }?
     .to_string();

--- a/contracts/injective-cosmwasm-stargate-example/src/reply.rs
+++ b/contracts/injective-cosmwasm-stargate-example/src/reply.rs
@@ -43,8 +43,8 @@ pub fn handle_create_order_reply_stargate(deps: DepsMut<InjectiveQueryWrapper>, 
                 encode_query_message,
             );
             response_str = match stargate_response {
-                Ok(binary) => String::from_utf8(binary.to_vec()).unwrap_or_else(|e| format!("Failed to decode binary to string: {:?}", e)),
-                Err(e) => format!("Error: {:?}", e),
+                Ok(binary) => String::from_utf8(binary.to_vec()).unwrap_or_else(|e| format!("Failed to decode binary to string: {e:?}")),
+                Err(e) => format!("Error: {e:?}"),
             };
             cache.clear();
             ORDER_CALL_CACHE.save(deps.storage, &cache)?;
@@ -70,8 +70,8 @@ pub fn handle_create_derivative_order_reply_stargate(deps: DepsMut<InjectiveQuer
                 encode_query_message,
             );
             response_str = match stargate_response {
-                Ok(binary) => String::from_utf8(binary.to_vec()).unwrap_or_else(|e| format!("Failed to decode binary to string: {:?}", e)),
-                Err(e) => format!("Error: {:?}", e),
+                Ok(binary) => String::from_utf8(binary.to_vec()).unwrap_or_else(|e| format!("Failed to decode binary to string: {e:?}")),
+                Err(e) => format!("Error: {e:?}"),
             };
             cache.clear();
             ORDER_CALL_CACHE.save(deps.storage, &cache)?;

--- a/contracts/injective-cosmwasm-stargate-example/src/utils.rs
+++ b/contracts/injective-cosmwasm-stargate-example/src/utils.rs
@@ -510,7 +510,6 @@ pub fn set_address_of_pyth_contract(app: &InjectiveTestApp, validator: &SigningA
             params: Some(Params {
                 pyth_contract: pyth_address.address(),
                 chainlink_verifier_proxy_contract: "".to_string(),
-                accept_unverified_chainlink_data_streams_reports: true,
                 chainlink_data_streams_verification_gas_limit: 1000000,
             }),
         },

--- a/packages/injective-cosmwasm/Cargo.toml
+++ b/packages/injective-cosmwasm/Cargo.toml
@@ -6,14 +6,14 @@ license = "Apache-2.0"
 name = "injective-cosmwasm"
 readme = "README.md"
 repository = "https://github.com/InjectiveLabs/cw-injective/tree/dev/packages/injective-cosmwasm"
-version = "0.3.5-1"
+version = "0.3.6"
 
 [dependencies]
-cosmwasm-std    = { version = "3.0.2", features = ["cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "cosmwasm_2_0", "iterator", "stargate" ] }
+cosmwasm-std    = { version = "3.0.5", features = ["cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "cosmwasm_2_0", "iterator", "stargate" ] }
 cw-storage-plus = { version = "3.0.1" }
 ethereum-types  = { version = "0.5.2" }
 hex             = { version = "0.4.3", features = [ "serde" ] }
-injective-math  = { version = "0.3.5-1"}
+injective-math  = { version = "0.3.6" }
 schemars        = { version = "0.8.16" }
 serde           = { version = "1.0.196", default-features = false, features = [ "derive" ] }
 serde_repr      = { version = "0.1.17" }
@@ -35,5 +35,3 @@ opt-level = 3
 overflow-checks = true
 panic = 'abort'
 rpath = false
-
-

--- a/packages/injective-cosmwasm/src/exchange/privileged_action.rs
+++ b/packages/injective-cosmwasm/src/exchange/privileged_action.rs
@@ -42,5 +42,5 @@ pub struct PrivilegedAction {
 }
 
 pub fn coins_to_string(coins: Vec<Coin>) -> String {
-    coins.into_iter().map(|coin| format!("{}", coin)).collect::<Vec<String>>().join(", ")
+    coins.into_iter().map(|coin| format!("{coin}")).collect::<Vec<String>>().join(", ")
 }

--- a/packages/injective-cosmwasm/src/exchange/types.rs
+++ b/packages/injective-cosmwasm/src/exchange/types.rs
@@ -164,15 +164,12 @@ impl<'de> Deserialize<'de> for MarketId {
         let market_id = String::deserialize(deserializer)?;
 
         if !market_id.starts_with("0x") {
-            let error_message = format!("Invalid prefix in deserialization: market_id must start with 0x, received {}", market_id);
+            let error_message = format!("Invalid prefix in deserialization: market_id must start with 0x, received {market_id}");
             return Err(D::Error::custom(error_message));
         }
 
         if market_id.len() != 66 {
-            let error_message = format!(
-                "Invalid length in deserialization: market_id must be exactly 66 characters, received {}",
-                market_id
-            );
+            let error_message = format!("Invalid length in deserialization: market_id must be exactly 66 characters, received {market_id}");
             return Err(D::Error::custom(error_message));
         }
 
@@ -226,18 +223,12 @@ impl<'de> Deserialize<'de> for SubaccountId {
         let subaccount_id = String::deserialize(deserializer)?;
 
         if !subaccount_id.starts_with("0x") {
-            let error_message = format!(
-                "Invalid prefix in deserialization: subaccount_id must start with 0x, received {}",
-                subaccount_id
-            );
+            let error_message = format!("Invalid prefix in deserialization: subaccount_id must start with 0x, received {subaccount_id}");
             return Err(D::Error::custom(error_message));
         }
 
         if subaccount_id.len() != 66 {
-            let error_message = format!(
-                "Invalid length in deserialization: subaccount_id must be exactly 66 characters, received {}",
-                subaccount_id
-            );
+            let error_message = format!("Invalid length in deserialization: subaccount_id must be exactly 66 characters, received {subaccount_id}");
             return Err(D::Error::custom(error_message));
         }
 
@@ -312,7 +303,7 @@ impl<'de> Deserialize<'de> for ShortSubaccountId {
         let id = String::deserialize(deserializer)?;
 
         match id.parse::<u16>() {
-            Ok(value) if value <= MAX_SHORT_SUBACCOUNT_NONCE => Ok(ShortSubaccountId::unchecked(format!("{:03x}", value))),
+            Ok(value) if value <= MAX_SHORT_SUBACCOUNT_NONCE => Ok(ShortSubaccountId::unchecked(format!("{value:03x}"))),
             _ => {
                 let maybe_long = SubaccountId::unchecked(id);
                 let maybe_short: ShortSubaccountId = ShortSubaccountId::from(maybe_long);

--- a/packages/injective-math/Cargo.toml
+++ b/packages/injective-math/Cargo.toml
@@ -6,12 +6,12 @@ license     = "Apache-2.0"
 name        = "injective-math"
 readme      = "README.md"
 repository  = "https://github.com/InjectiveLabs/cw-injective/tree/dev/packages/injective-math"
-version     = "0.3.5-1"
+version     = "0.3.6"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std    = { version = "3.0.2", features = ["cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "cosmwasm_2_0", "iterator", "stargate" ] }
+cosmwasm-std    = { version = "3.0.5", features = ["cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "cosmwasm_2_0", "iterator", "stargate" ] }
 primitive-types = { version = "0.12.2", default-features = false }
 schemars        = { version = "0.8.16" }
 serde           = { version = "1.0.196", default-features = false, features = [ "derive" ] }

--- a/packages/injective-testing/Cargo.toml
+++ b/packages/injective-testing/Cargo.toml
@@ -5,16 +5,16 @@ edition     = "2021"
 license     = "Apache-2.0"
 name        = "injective-testing"
 repository  = "https://github.com/InjectiveLabs/cw-injective/tree/dev/packages/injective-testing"
-version     = "1.18.0"
+version     = "1.19.0"
 
 [dependencies]
 anyhow              = { version = "1.0.66" }
-cosmwasm-std        = { version = "3.0.2", features = [ "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "cosmwasm_2_0", "iterator", "stargate" ] }
+cosmwasm-std        = { version = "3.0.5", features = [ "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "cosmwasm_2_0", "iterator", "stargate" ] }
 cw-multi-test       = { version = "3.0.1" }
-injective-cosmwasm  = { version = "0.3.5-1" }
-injective-math      = { version = "0.3.5-1" }
-injective-std       = { version = "1.18.0" }
-injective-test-tube = { version = "1.18.0" }
+injective-cosmwasm  = { version = "0.3.6" }
+injective-math      = { version = "0.3.6" }
+injective-std       = { version = "1.19.0" }
+injective-test-tube = { version = "1.19.0" }
 prost               = { version = "0.13.5", features = [ "prost-derive" ] }
 rand                = { version = "0.4.6" }
 regex               = { version = "1.11.1" }

--- a/packages/injective-testing/src/multi_test/chain_mock.rs
+++ b/packages/injective-testing/src/multi_test/chain_mock.rs
@@ -283,7 +283,7 @@ impl Module for CustomInjectiveHandler {
         _block: &BlockInfo,
         msg: Self::SudoT,
     ) -> Result<AppResponse, StdError> {
-        Err(StdError::msg(format!("Unexpected sudo msg {:?}", msg)))
+        Err(StdError::msg(format!("Unexpected sudo msg {msg:?}")))
     }
 }
 

--- a/packages/injective-testing/src/utils.rs
+++ b/packages/injective-testing/src/utils.rs
@@ -2,17 +2,11 @@ use cosmwasm_std::{coin, Coin};
 use injective_math::{scale::Scaled, FPDecimal};
 
 pub fn assert_execute_error(message: &str) -> String {
-    format!(
-        "execute error: failed to execute message; message index: 0: {}: execute wasm contract failed",
-        message
-    )
+    format!("execute error: failed to execute message; message index: 0: {message}: execute wasm contract failed")
 }
 
 pub fn assert_instantiate_error(message: &str) -> String {
-    format!(
-        "execute error: failed to execute message; message index: 0: {}: instantiate wasm contract failed",
-        message
-    )
+    format!("execute error: failed to execute message; message index: 0: {message}: instantiate wasm contract failed")
 }
 
 pub fn proto_to_dec(val: &str) -> FPDecimal {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel    = "1.86.0"
+channel    = "1.88.0"
 components = [ "rustfmt" ]
 profile    = "minimal"
 targets    = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
## Summary
- upgrade the workspace toolchain to Rust 1.88.0
- bump cosmwasm-std to 3.0.5
- bump injective-math to 0.3.6
- bump injective-cosmwasm to 0.3.6
- bump injective-testing to 1.19.0
- refresh example/mock contract manifests and Cargo.lock

## Published crates
- injective-math 0.3.6
- injective-cosmwasm 0.3.6
- injective-testing 1.19.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Rust toolchain to 1.88.0
  * Upgraded cosmwasm-std to 3.0.5
  * Bumped Injective crates to new versions (injective-cosmwasm/math to 0.3.6; injective-std/test-tube/injective-testing to 1.19.0)
  * Removed commented local override entries from config

* **Bug Fixes**
  * Oracle update messages no longer enable unverified Chainlink data streams by default when updating Pyth params

* **Style**
  * Improved internal error and debug message formatting for clearer logs and messages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->